### PR TITLE
Ensure deposit labels are unique

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,6 +1,7 @@
 import os
 import time
 import asyncio
+import uuid
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Union, Optional, List, Dict
 
@@ -313,7 +314,8 @@ async def deposit_create(body: DepositCreateIn):
 
     conn = await db()
     await ensure_user(conn, body.user_id)
-    label = f"dep:{body.user_id}:{int(time.time())}"
+    # Используем UUID, чтобы избежать коллизий меток при нескольких запросах в одну секунду
+    label = f"dep:{body.user_id}:{uuid.uuid4().hex}"
 
     now = int(time.time())
 


### PR DESCRIPTION
## Summary
- avoid duplicate deposit labels by using a UUID instead of timestamp

## Testing
- `python -m py_compile backend.py`
- `python - <<'PY'
import asyncio
from backend import deposit_create, DepositCreateIn, startup, shutdown

async def main():
    await startup()
    try:
        body = DepositCreateIn(user_id=1, amount=10)
        print('first', await deposit_create(body))
        print('second', await deposit_create(body))
    finally:
        await shutdown()
asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f68e61a608327b0fe1c60f2e77a94